### PR TITLE
docs: add UID hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ GWR synchronisation for ebau projects
 After installing and configuring those, download [docker-compose.yml](https://raw.githubusercontent.com/inosca/ebau-gwr/main/docker-compose.yml) and run the following command:
 
 ```bash
+echo UID=$UID > .env
+
 docker compose up -d
 ```
 


### PR DESCRIPTION
Without adding the `uid` docker compose won't come up.