### PR TITLE
fix: compatibility with psycopg>3.0.17

### DIFF
--- a/ebau_gwr/token_proxy/models.py
+++ b/ebau_gwr/token_proxy/models.py
@@ -21,7 +21,9 @@ class FernetStringField(models.BinaryField):
     def from_db_value(self, value, *_):
         if value is None:
             return value
-        return self.decrypt(value.tobytes())
+        if hasattr(value, "tobytes"):
+            value = value.tobytes()
+        return self.decrypt(value)
 
     def get_prep_value(self, value):
         value = super().get_prep_value(value)


### PR DESCRIPTION
In newer psycopg versions, the `value` of BinaryFields is `bytes` instead of `memoryview`.
See
https://forum.djangoproject.com/t/binaryfield-value-type-differs-across-databases/23785/4